### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ Use [Carthage](https://github.com/Carthage/Carthage). OptionKit uses semantic ve
 the corresponding Cartfile line should be:
 
 ```
-github "nomothetis/OptionKit" ~> 0.2.0
+github "nomothetis/OptionKit" ~> 1.0.0
 ```
 
 ### To Do


### PR DESCRIPTION
0.2.0 on this line lead to failed builds with LlamaKit, using 1.0.0 instead works.